### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-/build
-/lean_packages
 /.lake


### PR DESCRIPTION
These directories are no longer used by lake. If you still have these directories around, just delete them.