### PR TITLE
fix: check if at end before calling `Input.curr` on parsec parser

### DIFF
--- a/BibtexQuery/TexDiacritics.lean
+++ b/BibtexQuery/TexDiacritics.lean
@@ -279,7 +279,7 @@ def mathContent : Parser (Option TexContent) := fun it =>
     ((.some <| .math "$" ·) <$> aux "\\(" "\\)") it
   else if substr = "$$" then
     ((.some <| .math "$$" ·) <$> aux "$$" "$$") it
-  else if Input.curr it = '$' then
+  else if Input.hasNext it && Input.curr it = '$' then
     ((.some <| .math "$" ·) <$> aux "$" "$") it
   else
     .success it .none


### PR DESCRIPTION
This PR fixes the issue reported at https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.C2.ABdoc-gen4.C2.BB.2FbibPrepass.20PANIC.20at.20String.2ESlice.2EPos.2Eget!

The PR is against `nightly-testing` because that is what `doc-gen4` actually imports as far as I can tell.